### PR TITLE
Add missing dependencies. Fixes #1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,14 @@ setup(name='groundwire.register_form_recaptcha',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
-          'setuptools',
           'collective.recaptcha',
-          # -*- Extra requirements: -*-
+          'plone.app.users',
+          'setuptools',
+          'zope.app.form',
+          'zope.app.pagetemplate',
+          'zope.formlib',
+          'zope.interface',
+          'zope.schema',
       ],
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
Instead of only ``zope.app.pagetemplate`` - which fixes #1 - I just added all missing dependencies: those, which are directly imported but not declared, even if they are obvious deps from the whole Plone stack...